### PR TITLE
feat: matrix runner — libvirt + cloud-localds + parallel + NFS overlay

### DIFF
--- a/distros.tsv
+++ b/distros.tsv
@@ -17,6 +17,7 @@ centos-stream-10	rhel	centos	centos/CentOS-Stream-GenericCloud-x86_64-10-2026042
 fedora-44	rhel	fedora	fedora/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
 ubuntu-24.04	debian	ubuntu	ubuntu/ubuntu-24.04-server-cloudimg-amd64.img
 ubuntu-25.10	debian	ubuntu	ubuntu/ubuntu-25.10-server-cloudimg-amd64.img
-debian-12	debian	debian	debian/debian-12-genericcloud-amd64.qcow2
+# debian-12 hangs at boot — see https://github.com/aclater/distro-matrix/issues/3
+# debian-12	debian	debian	debian/debian-12-genericcloud-amd64.qcow2
 debian-13	debian	debian	debian/debian-13-genericcloud-amd64.qcow2
 # sles-15	suse	sles	sles/<populate after manual SCC download>

--- a/distros.tsv
+++ b/distros.tsv
@@ -1,0 +1,22 @@
+# alias	family	expected_os_id	qcow2_relpath
+# alias is what Incus will name the imported image (prefixed with dm/) and the launched VM (prefixed with dm-).
+# expected_os_id is the value the matrix runner asserts against the scanner's parsed /etc/os-release ID field.
+# qcow2_relpath is relative to --image-root (default /mnt/pool0/media/iso/linux on TrueNAS, /mnt/media/iso/linux from harrison NFS).
+# Lines starting with # are ignored. Tabs separate fields.
+rhel-8	rhel	rhel	rhel/rhel-8.10-x86_64-kvm.qcow2
+rhel-9	rhel	rhel	rhel/rhel-9.7-x86_64-kvm.qcow2
+rhel-10	rhel	rhel	rhel/rhel-10.1-x86_64-kvm.qcow2
+rocky-8	rhel	rocky	rocky/Rocky-8-GenericCloud-LVM-8.10-20240528.0.x86_64.qcow2
+rocky-9	rhel	rocky	rocky/Rocky-9-GenericCloud-Base-9.7-20251123.2.x86_64.qcow2
+rocky-10	rhel	rocky	rocky/Rocky-10-GenericCloud-LVM-10.1-20251116.0.x86_64.qcow2
+alma-8	rhel	almalinux	almalinux/AlmaLinux-8-GenericCloud-8.10-20260414.x86_64.qcow2
+alma-9	rhel	almalinux	almalinux/AlmaLinux-9-GenericCloud-9.7-20260414.x86_64.qcow2
+alma-10	rhel	almalinux	almalinux/AlmaLinux-10-GenericCloud-10.1-20260414.0.x86_64.qcow2
+centos-stream-9	rhel	centos	centos/CentOS-Stream-GenericCloud-x86_64-9-20260427.0.x86_64.qcow2
+centos-stream-10	rhel	centos	centos/CentOS-Stream-GenericCloud-x86_64-10-20260427.0.x86_64.qcow2
+fedora-44	rhel	fedora	fedora/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+ubuntu-24.04	debian	ubuntu	ubuntu/ubuntu-24.04-server-cloudimg-amd64.img
+ubuntu-25.10	debian	ubuntu	ubuntu/ubuntu-25.10-server-cloudimg-amd64.img
+debian-12	debian	debian	debian/debian-12-genericcloud-amd64.qcow2
+debian-13	debian	debian	debian/debian-13-genericcloud-amd64.qcow2
+# sles-15	suse	sles	sles/<populate after manual SCC download>

--- a/scripts/run-matrix.sh
+++ b/scripts/run-matrix.sh
@@ -340,7 +340,9 @@ run_one() {
 log "concurrency: $PARALLEL"
 for i in "${!ALIASES[@]}"; do
   while (( $(jobs -p -r | wc -l) >= PARALLEL )); do
-    wait -n
+    # `wait -n` exits 127 if no children (race: job finished between the
+    # count check and the wait). Swallow that under set -e.
+    wait -n 2>/dev/null || true
   done
   run_one "$i" &
 done

--- a/scripts/run-matrix.sh
+++ b/scripts/run-matrix.sh
@@ -1,34 +1,44 @@
 #!/usr/bin/env bash
-# distro-matrix runner — launch a fresh Incus VM per distro, run a scanner
-# script inside, pull the JSON output back, validate, emit a markdown report.
+# distro-matrix runner — boot a fresh libvirt VM per distro from a local cloud
+# qcow2, inject a NoCloud cidata.iso so cloud-init creates a `matrix` user with
+# our SSH key, run the scanner over SSH, pull JSON output back, and emit a
+# markdown report.
 #
-# Assumes the host running this script has the `incus` CLI configured to talk
-# to a daemon that can read qcow2 paths under --image-root. Easiest setup:
-# run this on the TrueNAS host where Incus owns /mnt/pool0/media/iso/linux/
-# directly. From a workstation, you can also point `incus remote` at TrueNAS
-# but qcow2s will be uploaded over the network at import time.
+# Why libvirt + cloud-localds (not Incus): the Incus path required either
+# Incus-flavored stripped images (no cloud-init, defeats the purpose) or
+# wrestling with Incus-side cloud-init injection that silently no-ops on
+# hand-imported qcow2s. The cloud-localds + virt-install flow is what every
+# upstream cloud image is tested against, so it just works.
 #
 # Usage:
-#   scripts/run-matrix.sh --scanner /path/to/scanner.sh [opts]
+#   scripts/run-matrix.sh --scanner /path/to/scanner [opts]
 #
 # Required:
-#   --scanner PATH            Local path to the scanner script (any executable
-#                             that prints JSON to stdout). Pushed into each VM
-#                             at /usr/local/bin/scanner and invoked as root.
+#   --scanner PATH            Local path to the scanner. Pushed to the VM at
+#                             /usr/local/bin/scanner and invoked as root via
+#                             sudo. stdout → result.json, stderr → stderr.log.
 #
 # Optional:
-#   --distros PATH            distros.tsv (default: ./distros.tsv)
-#   --image-root PATH         Where qcow2s live (default: /mnt/pool0/media/iso/linux,
-#                             falls back to /mnt/media/iso/linux if the first is absent)
-#   --results-dir PATH        Where reports land (default: ./results/<UTC ts>)
+#   --scanner-args 'STR'      Extra args to pass to the scanner (e.g. '--json').
+#
+# Optional:
+#   --distros PATH            distros.tsv (default: <repo>/distros.tsv)
+#   --image-root PATH         Where qcow2s live (default: /mnt/media/iso/linux)
+#   --results-dir PATH        Where reports land (default: <repo>/results/<UTC ts>)
+#   --work-dir PATH           Per-VM disk + cidata staging (default: /tmp/distro-matrix-work)
 #   --only LIST               Comma-separated alias subset (e.g. debian-13,rhel-9)
 #   --skip LIST               Comma-separated aliases to skip
 #   --vcpus N                 vCPUs per VM (default: 1)
 #   --memory MIB              RAM per VM in MiB (default: 1536)
-#   --disk GIB                Disk per VM in GiB (default: 10)
-#   --boot-timeout SEC        Max seconds to wait for incus-agent + scanner (default: 300)
-#   --keep-on-failure         Don't delete VMs whose scanner failed (debug)
-#   --reuse-images            Don't reimport an image if dm/<alias> already exists
+#   --disk GIB                Resize qcow2 to this GiB before boot (default: 10)
+#   --boot-timeout SEC        Max seconds for IP + SSH (default: 240)
+#   --scanner-timeout SEC     Max seconds for the scanner itself (default: 300)
+#   --ssh-key PATH            SSH pubkey to inject (default: ~/.ssh/id_rsa.pub)
+#   --parallel N              Run N distros in parallel (default: 1)
+#   --no-backing              Copy qcow2 instead of using qemu-img backing-file overlay.
+#                             Use this if --image-root isn't libvirt-readable.
+#   --keep-on-failure         Leave the VM + workdir for the failed distro (debug)
+#   --connect URI             libvirt URI (default: qemu:///system)
 #   --help
 
 set -euo pipefail
@@ -38,68 +48,76 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # Defaults
 DISTROS_FILE="$REPO_ROOT/distros.tsv"
-IMAGE_ROOT=""
+IMAGE_ROOT=/mnt/media/iso/linux
 RESULTS_DIR=""
+WORK_DIR=/tmp/distro-matrix-work
 SCANNER=""
+SCANNER_ARGS=""
 ONLY=""
 SKIP=""
 VCPUS=1
 MEMORY=1536
 DISK=10
-BOOT_TIMEOUT=300
+BOOT_TIMEOUT=240
+SCANNER_TIMEOUT=300
+SSH_KEY="$HOME/.ssh/id_rsa.pub"
+PARALLEL=1
+NO_BACKING=0
 KEEP_ON_FAILURE=0
-REUSE_IMAGES=0
+LIBVIRT_URI=qemu:///system
 
 usage() { sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --scanner) SCANNER=$2; shift 2 ;;
+    --scanner-args) SCANNER_ARGS=$2; shift 2 ;;
     --distros) DISTROS_FILE=$2; shift 2 ;;
     --image-root) IMAGE_ROOT=$2; shift 2 ;;
     --results-dir) RESULTS_DIR=$2; shift 2 ;;
+    --work-dir) WORK_DIR=$2; shift 2 ;;
     --only) ONLY=$2; shift 2 ;;
     --skip) SKIP=$2; shift 2 ;;
     --vcpus) VCPUS=$2; shift 2 ;;
     --memory) MEMORY=$2; shift 2 ;;
     --disk) DISK=$2; shift 2 ;;
     --boot-timeout) BOOT_TIMEOUT=$2; shift 2 ;;
+    --scanner-timeout) SCANNER_TIMEOUT=$2; shift 2 ;;
+    --ssh-key) SSH_KEY=$2; shift 2 ;;
+    --parallel) PARALLEL=$2; shift 2 ;;
+    --no-backing) NO_BACKING=1; shift ;;
     --keep-on-failure) KEEP_ON_FAILURE=1; shift ;;
-    --reuse-images) REUSE_IMAGES=1; shift ;;
+    --connect) LIBVIRT_URI=$2; shift 2 ;;
     --help|-h) usage 0 ;;
     *) echo "unknown arg: $1" >&2; usage 2 ;;
   esac
 done
 
 [[ -n $SCANNER ]] || { echo "--scanner is required" >&2; usage 2; }
-[[ -x $SCANNER || -r $SCANNER ]] || { echo "scanner not found or unreadable: $SCANNER" >&2; exit 2; }
+[[ -r $SCANNER ]] || { echo "scanner not readable: $SCANNER" >&2; exit 2; }
 [[ -r $DISTROS_FILE ]] || { echo "distros file not readable: $DISTROS_FILE" >&2; exit 2; }
-command -v incus >/dev/null || { echo "incus CLI not found in PATH" >&2; exit 2; }
-command -v jq >/dev/null || { echo "jq not found in PATH" >&2; exit 2; }
-
-if [[ -z $IMAGE_ROOT ]]; then
-  if [[ -d /mnt/pool0/media/iso/linux ]]; then
-    IMAGE_ROOT=/mnt/pool0/media/iso/linux
-  elif [[ -d /mnt/media/iso/linux ]]; then
-    IMAGE_ROOT=/mnt/media/iso/linux
-  else
-    echo "--image-root not given and no default path exists" >&2
-    exit 2
-  fi
-fi
+[[ -r $SSH_KEY ]] || { echo "ssh pubkey not readable: $SSH_KEY" >&2; exit 2; }
 [[ -d $IMAGE_ROOT ]] || { echo "image-root not a directory: $IMAGE_ROOT" >&2; exit 2; }
+for cmd in virsh virt-install cloud-localds qemu-img jq ssh scp; do
+  command -v "$cmd" >/dev/null || { echo "missing required tool: $cmd" >&2; exit 2; }
+done
 
 if [[ -z $RESULTS_DIR ]]; then
   RESULTS_DIR="$REPO_ROOT/results/$(date -u +%Y%m%dT%H%M%SZ)"
 fi
-mkdir -p "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR" "$WORK_DIR"
 
 REPORT="$RESULTS_DIR/report.md"
 SUMMARY_JSON="$RESULTS_DIR/summary.json"
+SSH_KEY_PRIV="${SSH_KEY%.pub}"
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
 
-# --- Parse distros.tsv into parallel arrays --------------------------------
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+          -o LogLevel=ERROR -o ConnectTimeout=10
+          -o BatchMode=yes -o GlobalKnownHostsFile=/dev/null)
+
+# --- Parse distros.tsv -----------------------------------------------------
 declare -a ALIASES FAMILIES EXPECTED_OS QCOW_PATHS
 while IFS=$'\t' read -r alias family expected_os qcow_relpath; do
   [[ $alias =~ ^# ]] && continue
@@ -119,34 +137,57 @@ fi
 
 log "matrix: ${#ALIASES[@]} distro(s) — ${ALIASES[*]}"
 log "results dir: $RESULTS_DIR"
+log "work dir: $WORK_DIR"
 
-# --- Cloud-init user-data --------------------------------------------------
-# We bake the scanner into write_files (base64) so we don't need network or
-# SSH inside the guest. runcmd executes it, captures stdout/stderr/exit, and
-# touches a marker file we poll for via `incus file pull`.
-SCANNER_B64=$(base64 -w0 < "$SCANNER")
+PUBKEY_CONTENT=$(< "$SSH_KEY")
 
-render_userdata() {
-  local hostname=$1
-  cat <<EOF
+# --- Per-distro state ------------------------------------------------------
+# Parallel runs write their record to $RESULTS_DIR/<alias>/record.tsv so the
+# parent doesn't have to share an in-memory array (subshells can't write back).
+
+write_userdata() {
+  local hostname=$1 path=$2
+  cat > "$path" <<EOF
 #cloud-config
 hostname: $hostname
 manage_etc_hosts: true
-write_files:
-  - path: /usr/local/bin/scanner
-    permissions: '0755'
-    encoding: b64
-    content: $SCANNER_B64
-runcmd:
-  - mkdir -p /var/run/distro-matrix
-  - bash -c '/usr/local/bin/scanner > /var/run/distro-matrix/result.json 2> /var/run/distro-matrix/stderr.log; echo \$? > /var/run/distro-matrix/exit-code'
-  - touch /var/run/distro-matrix/done
+ssh_pwauth: false
+users:
+  - name: matrix
+    groups: [sudo, wheel]
+    sudo: 'ALL=(ALL) NOPASSWD:ALL'
+    shell: /bin/bash
+    lock_passwd: true
+    ssh_authorized_keys:
+      - $PUBKEY_CONTENT
 EOF
 }
 
-# --- Per-distro work -------------------------------------------------------
-declare -a ROW_ALIAS ROW_EXPECTED ROW_DETECTED ROW_EXIT ROW_DURATION ROW_VERDICT ROW_NOTES
-declare -i N_PASS=0 N_FAIL=0
+vm_ipv4() {
+  virsh -c "$LIBVIRT_URI" domifaddr "$1" 2>/dev/null \
+    | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}'
+}
+
+cleanup_vm() {
+  local vm=$1 work=$2 verdict=$3
+  if [[ $verdict == "FAIL" && $KEEP_ON_FAILURE -eq 1 ]]; then
+    log "[$vm] keeping VM + work dir (debug)"
+    return
+  fi
+  virsh -c "$LIBVIRT_URI" destroy "$vm" >/dev/null 2>&1 || true
+  virsh -c "$LIBVIRT_URI" undefine "$vm" --remove-all-storage --nvram >/dev/null 2>&1 \
+    || virsh -c "$LIBVIRT_URI" undefine "$vm" --remove-all-storage >/dev/null 2>&1 \
+    || true
+  rm -rf "$work"
+}
+
+record() {
+  # alias \t expected \t detected \t exit \t duration \t verdict \t notes
+  local out_dir="$RESULTS_DIR/$1"
+  mkdir -p "$out_dir"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7" \
+    > "$out_dir/record.tsv"
+}
 
 run_one() {
   local idx=$1
@@ -154,8 +195,8 @@ run_one() {
   local family=${FAMILIES[$idx]}
   local expected=${EXPECTED_OS[$idx]}
   local qcow=${QCOW_PATHS[$idx]}
-  local image="dm/$alias"
   local vm="dm-$alias"
+  local work="$WORK_DIR/$alias"
   local out_dir="$RESULTS_DIR/$alias"
   local notes=""
   local detected_id=""
@@ -163,7 +204,7 @@ run_one() {
   local verdict="FAIL"
   local started=$SECONDS
 
-  mkdir -p "$out_dir"
+  mkdir -p "$out_dir" "$work"
   log "[$alias] start"
 
   if [[ ! -r $qcow ]]; then
@@ -173,101 +214,154 @@ run_one() {
     return
   fi
 
-  # Import (idempotent if --reuse-images and image already cached)
-  if (( REUSE_IMAGES )) && incus image show "$image" >/dev/null 2>&1; then
-    log "[$alias] reuse cached image $image"
-  else
-    incus image show "$image" >/dev/null 2>&1 && incus image delete "$image" >/dev/null 2>&1 || true
-    log "[$alias] importing $qcow → $image"
-    if ! incus image import "$qcow" --alias "$image" >>"$out_dir/incus.log" 2>&1; then
-      notes="image import failed (see $out_dir/incus.log)"
-      record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
-      return
-    fi
-  fi
+  # Make sure no leftover VM by this name
+  virsh -c "$LIBVIRT_URI" destroy "$vm" >/dev/null 2>&1 || true
+  virsh -c "$LIBVIRT_URI" undefine "$vm" --remove-all-storage >/dev/null 2>&1 || true
 
-  # Init VM with cloud-init
-  render_userdata "$vm" > "$out_dir/user-data.yaml"
-  if ! incus init "$image" "$vm" --vm \
-        -c limits.cpu="$VCPUS" \
-        -c limits.memory="${MEMORY}MiB" \
-        -d root,size="${DISK}GiB" \
-        >>"$out_dir/incus.log" 2>&1; then
-    notes="incus init failed"
+  # Stage disk + cidata.iso. By default, create a thin qcow2 overlay backed
+  # by the upstream qcow2 — qemu reads the base over NFS, writes to the
+  # local overlay (typically tens of MB). --no-backing falls back to a full
+  # copy for setups where qemu can't reach the image-root.
+  if (( NO_BACKING )); then
+    log "[$alias] copying qcow2 ($(du -h "$qcow" | cut -f1))"
+    cp "$qcow" "$work/disk.qcow2"
+    qemu-img resize "$work/disk.qcow2" "${DISK}G" >>"$out_dir/virt.log" 2>&1
+  else
+    log "[$alias] backing-file overlay over $qcow"
+    qemu-img create -f qcow2 -F qcow2 -b "$qcow" "$work/disk.qcow2" "${DISK}G" \
+      >>"$out_dir/virt.log" 2>&1
+  fi
+  write_userdata "$vm" "$work/user-data"
+  printf 'instance-id: %s-%s\nlocal-hostname: %s\n' "$vm" "$(date -u +%s)" "$vm" > "$work/meta-data"
+  cloud-localds "$work/cidata.iso" "$work/user-data" "$work/meta-data" \
+    >>"$out_dir/virt.log" 2>&1
+
+  # Boot
+  log "[$alias] virt-install"
+  if ! virt-install \
+        --connect "$LIBVIRT_URI" \
+        --name "$vm" \
+        --memory "$MEMORY" \
+        --vcpus "$VCPUS" \
+        --disk "path=$work/disk.qcow2,format=qcow2" \
+        --disk "path=$work/cidata.iso,device=cdrom" \
+        --import \
+        --os-variant detect=on,name=linux2024 \
+        --network network=default \
+        --graphics none \
+        --noautoconsole \
+        >>"$out_dir/virt.log" 2>&1; then
+    notes="virt-install failed (see $out_dir/virt.log)"
+    cleanup_vm "$vm" "$work" "FAIL"
     record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
     return
   fi
-  incus config set "$vm" user.user-data - < "$out_dir/user-data.yaml"
-  incus start "$vm" >>"$out_dir/incus.log" 2>&1
 
-  # Wait for cloud-init to finish (marker file appears)
+  # Wait for IPv4 from libvirt's default network DHCP
   local deadline=$(( SECONDS + BOOT_TIMEOUT ))
-  local marker_seen=0
+  local ip=""
   while (( SECONDS < deadline )); do
-    if incus file pull "$vm/var/run/distro-matrix/done" - >/dev/null 2>&1; then
-      marker_seen=1
+    ip=$(vm_ipv4 "$vm")
+    [[ -n $ip ]] && break
+    sleep 5
+  done
+  if [[ -z $ip ]]; then
+    notes="no IPv4 within ${BOOT_TIMEOUT}s"
+    cleanup_vm "$vm" "$work" "FAIL"
+    record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
+    return
+  fi
+  log "[$alias] ip=$ip"
+
+  # Wait for SSH (cloud-init may still be applying user keys)
+  local ssh_ready=0
+  while (( SECONDS < deadline )); do
+    if ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "matrix@$ip" true >/dev/null 2>&1; then
+      ssh_ready=1
       break
     fi
     sleep 5
   done
-
-  if (( ! marker_seen )); then
-    notes="boot/scanner timeout after ${BOOT_TIMEOUT}s"
-    cleanup_vm "$vm" "$out_dir" "FAIL"
+  if (( ! ssh_ready )); then
+    notes="SSH never ready within ${BOOT_TIMEOUT}s"
+    cleanup_vm "$vm" "$work" "FAIL"
     record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
     return
   fi
 
-  # Pull artifacts
-  incus file pull "$vm/var/run/distro-matrix/result.json" "$out_dir/result.json" 2>>"$out_dir/incus.log" || true
-  incus file pull "$vm/var/run/distro-matrix/stderr.log" "$out_dir/stderr.log" 2>>"$out_dir/incus.log" || true
-  incus file pull "$vm/var/run/distro-matrix/exit-code" "$out_dir/exit-code" 2>>"$out_dir/incus.log" || true
-  exit_code=$(tr -d '[:space:]' < "$out_dir/exit-code" 2>/dev/null || echo "?")
+  # Push scanner and run as root
+  log "[$alias] pushing scanner + running"
+  scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$SCANNER" "matrix@$ip:/tmp/scanner" \
+    >>"$out_dir/virt.log" 2>&1
+  ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "matrix@$ip" "
+    sudo install -m 0755 /tmp/scanner /usr/local/bin/scanner
+    timeout ${SCANNER_TIMEOUT}s sudo /usr/local/bin/scanner $SCANNER_ARGS > /tmp/result.json 2> /tmp/stderr.log
+    echo \$? > /tmp/exit-code
+    sudo cp /etc/os-release /tmp/os-release
+    sudo chown matrix:matrix /tmp/result.json /tmp/stderr.log /tmp/exit-code /tmp/os-release
+  " 2>>"$out_dir/virt.log" || true
 
-  # Pull the guest's /etc/os-release for ground-truth comparison
-  incus file pull "$vm/etc/os-release" "$out_dir/os-release" 2>>"$out_dir/incus.log" || true
+  # Pull artifacts
+  for f in result.json stderr.log exit-code os-release; do
+    scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "matrix@$ip:/tmp/$f" "$out_dir/$f" \
+      >>"$out_dir/virt.log" 2>&1 || true
+  done
+
+  exit_code=$(tr -d '[:space:]' < "$out_dir/exit-code" 2>/dev/null || echo "?")
   if [[ -r $out_dir/os-release ]]; then
     detected_id=$(awk -F= '$1=="ID"{gsub(/"/,"",$2); print $2}' "$out_dir/os-release")
   fi
 
-  # Verdict: scanner exit 0 + os-release ID matches expected
-  if [[ $exit_code == "0" && $detected_id == "$expected" ]]; then
+  # Verdict: did the scanner RUN (vs crash)? We don't care what verdict the
+  # scanner itself reached. Treat 0-123 as "ran cleanly" (124 = `timeout`
+  # tripped, 125-128 / 137 / 143 = signals or wrapper errors).
+  local ran_cleanly=0
+  if [[ $exit_code =~ ^[0-9]+$ ]] && (( exit_code < 124 )); then
+    ran_cleanly=1
+  fi
+  if (( ran_cleanly )) && [[ -s $out_dir/result.json ]] && [[ $detected_id == "$expected" ]]; then
     verdict=PASS
-  elif [[ $exit_code == "0" ]]; then
+  elif (( ran_cleanly )) && [[ $detected_id != "$expected" ]]; then
     verdict=FAIL
     notes="os-id mismatch: expected=$expected detected=${detected_id:-<unread>}"
+  elif (( ran_cleanly )) && [[ ! -s $out_dir/result.json ]]; then
+    verdict=FAIL
+    notes="scanner exited cleanly but produced empty stdout"
   else
     verdict=FAIL
-    notes="scanner exit=$exit_code"
+    notes="scanner did not run cleanly (exit=$exit_code)"
   fi
 
-  cleanup_vm "$vm" "$out_dir" "$verdict"
+  cleanup_vm "$vm" "$work" "$verdict"
   record "$alias" "$expected" "$detected_id" "$exit_code" "$((SECONDS - started))" "$verdict" "$notes"
 }
 
-cleanup_vm() {
-  local vm=$1 out_dir=$2 verdict=$3
-  if [[ $verdict == "FAIL" && $KEEP_ON_FAILURE -eq 1 ]]; then
-    log "[$vm] keeping VM (debug)"
-    return
-  fi
-  incus delete --force "$vm" >>"$out_dir/incus.log" 2>&1 || true
-}
-
-record() {
-  ROW_ALIAS+=("$1")
-  ROW_EXPECTED+=("$2")
-  ROW_DETECTED+=("$3")
-  ROW_EXIT+=("$4")
-  ROW_DURATION+=("$5")
-  ROW_VERDICT+=("$6")
-  ROW_NOTES+=("$7")
-  if [[ $6 == PASS ]]; then N_PASS+=1; else N_FAIL+=1; fi
-}
-
-# --- Run sequentially (parallelism deferred) -------------------------------
+# --- Drive the matrix (sequential or parallel) -----------------------------
+log "concurrency: $PARALLEL"
 for i in "${!ALIASES[@]}"; do
-  run_one "$i"
+  while (( $(jobs -p -r | wc -l) >= PARALLEL )); do
+    wait -n
+  done
+  run_one "$i" &
+done
+wait
+
+# --- Aggregate per-distro records ------------------------------------------
+declare -i N_PASS=0 N_FAIL=0
+declare -a ROW_ALIAS ROW_EXPECTED ROW_DETECTED ROW_EXIT ROW_DURATION ROW_VERDICT ROW_NOTES
+for alias in "${ALIASES[@]}"; do
+  rec="$RESULTS_DIR/$alias/record.tsv"
+  if [[ ! -r $rec ]]; then
+    ROW_ALIAS+=("$alias"); ROW_EXPECTED+=("?"); ROW_DETECTED+=(""); ROW_EXIT+=("?")
+    ROW_DURATION+=("0"); ROW_VERDICT+=("FAIL"); ROW_NOTES+=("no record file (run_one crashed)")
+    N_FAIL+=1
+    continue
+  fi
+  IFS=$'\t' read -r r_alias r_exp r_det r_exit r_dur r_verd r_notes < "$rec"
+  ROW_ALIAS+=("$r_alias"); ROW_EXPECTED+=("$r_exp"); ROW_DETECTED+=("$r_det")
+  ROW_EXIT+=("$r_exit"); ROW_DURATION+=("$r_dur"); ROW_VERDICT+=("$r_verd")
+  ROW_NOTES+=("$r_notes")
+  if [[ $r_verd == PASS ]]; then N_PASS+=1; else N_FAIL+=1; fi
 done
 
 # --- Render report ---------------------------------------------------------
@@ -276,6 +370,7 @@ done
   echo
   echo "- timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   echo "- scanner: \`$SCANNER\`"
+  echo "- concurrency: $PARALLEL"
   echo "- distros: ${#ALIASES[@]} (pass: $N_PASS, fail: $N_FAIL)"
   echo
   echo "| Alias | Expected ID | Detected ID | Exit | Duration | Verdict | Notes |"
@@ -289,8 +384,8 @@ done
 
 # --- summary.json ----------------------------------------------------------
 {
-  printf '{"timestamp":"%s","scanner":"%s","total":%d,"pass":%d,"fail":%d,"results":[' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SCANNER" "${#ALIASES[@]}" "$N_PASS" "$N_FAIL"
+  printf '{"timestamp":"%s","scanner":"%s","concurrency":%d,"total":%d,"pass":%d,"fail":%d,"results":[' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SCANNER" "$PARALLEL" "${#ALIASES[@]}" "$N_PASS" "$N_FAIL"
   for i in "${!ROW_ALIAS[@]}"; do
     [[ $i -gt 0 ]] && printf ','
     jq -nc --arg a "${ROW_ALIAS[$i]}" --arg e "${ROW_EXPECTED[$i]}" \

--- a/scripts/run-matrix.sh
+++ b/scripts/run-matrix.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# distro-matrix runner — launch a fresh Incus VM per distro, run a scanner
+# script inside, pull the JSON output back, validate, emit a markdown report.
+#
+# Assumes the host running this script has the `incus` CLI configured to talk
+# to a daemon that can read qcow2 paths under --image-root. Easiest setup:
+# run this on the TrueNAS host where Incus owns /mnt/pool0/media/iso/linux/
+# directly. From a workstation, you can also point `incus remote` at TrueNAS
+# but qcow2s will be uploaded over the network at import time.
+#
+# Usage:
+#   scripts/run-matrix.sh --scanner /path/to/scanner.sh [opts]
+#
+# Required:
+#   --scanner PATH            Local path to the scanner script (any executable
+#                             that prints JSON to stdout). Pushed into each VM
+#                             at /usr/local/bin/scanner and invoked as root.
+#
+# Optional:
+#   --distros PATH            distros.tsv (default: ./distros.tsv)
+#   --image-root PATH         Where qcow2s live (default: /mnt/pool0/media/iso/linux,
+#                             falls back to /mnt/media/iso/linux if the first is absent)
+#   --results-dir PATH        Where reports land (default: ./results/<UTC ts>)
+#   --only LIST               Comma-separated alias subset (e.g. debian-13,rhel-9)
+#   --skip LIST               Comma-separated aliases to skip
+#   --vcpus N                 vCPUs per VM (default: 1)
+#   --memory MIB              RAM per VM in MiB (default: 1536)
+#   --disk GIB                Disk per VM in GiB (default: 10)
+#   --boot-timeout SEC        Max seconds to wait for incus-agent + scanner (default: 300)
+#   --keep-on-failure         Don't delete VMs whose scanner failed (debug)
+#   --reuse-images            Don't reimport an image if dm/<alias> already exists
+#   --help
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# Defaults
+DISTROS_FILE="$REPO_ROOT/distros.tsv"
+IMAGE_ROOT=""
+RESULTS_DIR=""
+SCANNER=""
+ONLY=""
+SKIP=""
+VCPUS=1
+MEMORY=1536
+DISK=10
+BOOT_TIMEOUT=300
+KEEP_ON_FAILURE=0
+REUSE_IMAGES=0
+
+usage() { sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scanner) SCANNER=$2; shift 2 ;;
+    --distros) DISTROS_FILE=$2; shift 2 ;;
+    --image-root) IMAGE_ROOT=$2; shift 2 ;;
+    --results-dir) RESULTS_DIR=$2; shift 2 ;;
+    --only) ONLY=$2; shift 2 ;;
+    --skip) SKIP=$2; shift 2 ;;
+    --vcpus) VCPUS=$2; shift 2 ;;
+    --memory) MEMORY=$2; shift 2 ;;
+    --disk) DISK=$2; shift 2 ;;
+    --boot-timeout) BOOT_TIMEOUT=$2; shift 2 ;;
+    --keep-on-failure) KEEP_ON_FAILURE=1; shift ;;
+    --reuse-images) REUSE_IMAGES=1; shift ;;
+    --help|-h) usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+[[ -n $SCANNER ]] || { echo "--scanner is required" >&2; usage 2; }
+[[ -x $SCANNER || -r $SCANNER ]] || { echo "scanner not found or unreadable: $SCANNER" >&2; exit 2; }
+[[ -r $DISTROS_FILE ]] || { echo "distros file not readable: $DISTROS_FILE" >&2; exit 2; }
+command -v incus >/dev/null || { echo "incus CLI not found in PATH" >&2; exit 2; }
+command -v jq >/dev/null || { echo "jq not found in PATH" >&2; exit 2; }
+
+if [[ -z $IMAGE_ROOT ]]; then
+  if [[ -d /mnt/pool0/media/iso/linux ]]; then
+    IMAGE_ROOT=/mnt/pool0/media/iso/linux
+  elif [[ -d /mnt/media/iso/linux ]]; then
+    IMAGE_ROOT=/mnt/media/iso/linux
+  else
+    echo "--image-root not given and no default path exists" >&2
+    exit 2
+  fi
+fi
+[[ -d $IMAGE_ROOT ]] || { echo "image-root not a directory: $IMAGE_ROOT" >&2; exit 2; }
+
+if [[ -z $RESULTS_DIR ]]; then
+  RESULTS_DIR="$REPO_ROOT/results/$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "$RESULTS_DIR"
+
+REPORT="$RESULTS_DIR/report.md"
+SUMMARY_JSON="$RESULTS_DIR/summary.json"
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
+
+# --- Parse distros.tsv into parallel arrays --------------------------------
+declare -a ALIASES FAMILIES EXPECTED_OS QCOW_PATHS
+while IFS=$'\t' read -r alias family expected_os qcow_relpath; do
+  [[ $alias =~ ^# ]] && continue
+  [[ -z $alias ]] && continue
+  if [[ -n $ONLY && ",$ONLY," != *",$alias,"* ]]; then continue; fi
+  if [[ -n $SKIP && ",$SKIP," == *",$alias,"* ]]; then continue; fi
+  ALIASES+=("$alias")
+  FAMILIES+=("$family")
+  EXPECTED_OS+=("$expected_os")
+  QCOW_PATHS+=("$IMAGE_ROOT/$qcow_relpath")
+done < "$DISTROS_FILE"
+
+if [[ ${#ALIASES[@]} -eq 0 ]]; then
+  echo "no distros selected (check --only/--skip and distros.tsv)" >&2
+  exit 1
+fi
+
+log "matrix: ${#ALIASES[@]} distro(s) — ${ALIASES[*]}"
+log "results dir: $RESULTS_DIR"
+
+# --- Cloud-init user-data --------------------------------------------------
+# We bake the scanner into write_files (base64) so we don't need network or
+# SSH inside the guest. runcmd executes it, captures stdout/stderr/exit, and
+# touches a marker file we poll for via `incus file pull`.
+SCANNER_B64=$(base64 -w0 < "$SCANNER")
+
+render_userdata() {
+  local hostname=$1
+  cat <<EOF
+#cloud-config
+hostname: $hostname
+manage_etc_hosts: true
+write_files:
+  - path: /usr/local/bin/scanner
+    permissions: '0755'
+    encoding: b64
+    content: $SCANNER_B64
+runcmd:
+  - mkdir -p /var/run/distro-matrix
+  - bash -c '/usr/local/bin/scanner > /var/run/distro-matrix/result.json 2> /var/run/distro-matrix/stderr.log; echo \$? > /var/run/distro-matrix/exit-code'
+  - touch /var/run/distro-matrix/done
+EOF
+}
+
+# --- Per-distro work -------------------------------------------------------
+declare -a ROW_ALIAS ROW_EXPECTED ROW_DETECTED ROW_EXIT ROW_DURATION ROW_VERDICT ROW_NOTES
+declare -i N_PASS=0 N_FAIL=0
+
+run_one() {
+  local idx=$1
+  local alias=${ALIASES[$idx]}
+  local family=${FAMILIES[$idx]}
+  local expected=${EXPECTED_OS[$idx]}
+  local qcow=${QCOW_PATHS[$idx]}
+  local image="dm/$alias"
+  local vm="dm-$alias"
+  local out_dir="$RESULTS_DIR/$alias"
+  local notes=""
+  local detected_id=""
+  local exit_code="?"
+  local verdict="FAIL"
+  local started=$SECONDS
+
+  mkdir -p "$out_dir"
+  log "[$alias] start"
+
+  if [[ ! -r $qcow ]]; then
+    notes="qcow2 missing: $qcow"
+    log "[$alias] $notes"
+    record "$alias" "$expected" "" "?" "0" "FAIL" "$notes"
+    return
+  fi
+
+  # Import (idempotent if --reuse-images and image already cached)
+  if (( REUSE_IMAGES )) && incus image show "$image" >/dev/null 2>&1; then
+    log "[$alias] reuse cached image $image"
+  else
+    incus image show "$image" >/dev/null 2>&1 && incus image delete "$image" >/dev/null 2>&1 || true
+    log "[$alias] importing $qcow → $image"
+    if ! incus image import "$qcow" --alias "$image" >>"$out_dir/incus.log" 2>&1; then
+      notes="image import failed (see $out_dir/incus.log)"
+      record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
+      return
+    fi
+  fi
+
+  # Init VM with cloud-init
+  render_userdata "$vm" > "$out_dir/user-data.yaml"
+  if ! incus init "$image" "$vm" --vm \
+        -c limits.cpu="$VCPUS" \
+        -c limits.memory="${MEMORY}MiB" \
+        -d root,size="${DISK}GiB" \
+        >>"$out_dir/incus.log" 2>&1; then
+    notes="incus init failed"
+    record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
+    return
+  fi
+  incus config set "$vm" user.user-data - < "$out_dir/user-data.yaml"
+  incus start "$vm" >>"$out_dir/incus.log" 2>&1
+
+  # Wait for cloud-init to finish (marker file appears)
+  local deadline=$(( SECONDS + BOOT_TIMEOUT ))
+  local marker_seen=0
+  while (( SECONDS < deadline )); do
+    if incus file pull "$vm/var/run/distro-matrix/done" - >/dev/null 2>&1; then
+      marker_seen=1
+      break
+    fi
+    sleep 5
+  done
+
+  if (( ! marker_seen )); then
+    notes="boot/scanner timeout after ${BOOT_TIMEOUT}s"
+    cleanup_vm "$vm" "$out_dir" "FAIL"
+    record "$alias" "$expected" "" "?" "$((SECONDS - started))" "FAIL" "$notes"
+    return
+  fi
+
+  # Pull artifacts
+  incus file pull "$vm/var/run/distro-matrix/result.json" "$out_dir/result.json" 2>>"$out_dir/incus.log" || true
+  incus file pull "$vm/var/run/distro-matrix/stderr.log" "$out_dir/stderr.log" 2>>"$out_dir/incus.log" || true
+  incus file pull "$vm/var/run/distro-matrix/exit-code" "$out_dir/exit-code" 2>>"$out_dir/incus.log" || true
+  exit_code=$(tr -d '[:space:]' < "$out_dir/exit-code" 2>/dev/null || echo "?")
+
+  # Pull the guest's /etc/os-release for ground-truth comparison
+  incus file pull "$vm/etc/os-release" "$out_dir/os-release" 2>>"$out_dir/incus.log" || true
+  if [[ -r $out_dir/os-release ]]; then
+    detected_id=$(awk -F= '$1=="ID"{gsub(/"/,"",$2); print $2}' "$out_dir/os-release")
+  fi
+
+  # Verdict: scanner exit 0 + os-release ID matches expected
+  if [[ $exit_code == "0" && $detected_id == "$expected" ]]; then
+    verdict=PASS
+  elif [[ $exit_code == "0" ]]; then
+    verdict=FAIL
+    notes="os-id mismatch: expected=$expected detected=${detected_id:-<unread>}"
+  else
+    verdict=FAIL
+    notes="scanner exit=$exit_code"
+  fi
+
+  cleanup_vm "$vm" "$out_dir" "$verdict"
+  record "$alias" "$expected" "$detected_id" "$exit_code" "$((SECONDS - started))" "$verdict" "$notes"
+}
+
+cleanup_vm() {
+  local vm=$1 out_dir=$2 verdict=$3
+  if [[ $verdict == "FAIL" && $KEEP_ON_FAILURE -eq 1 ]]; then
+    log "[$vm] keeping VM (debug)"
+    return
+  fi
+  incus delete --force "$vm" >>"$out_dir/incus.log" 2>&1 || true
+}
+
+record() {
+  ROW_ALIAS+=("$1")
+  ROW_EXPECTED+=("$2")
+  ROW_DETECTED+=("$3")
+  ROW_EXIT+=("$4")
+  ROW_DURATION+=("$5")
+  ROW_VERDICT+=("$6")
+  ROW_NOTES+=("$7")
+  if [[ $6 == PASS ]]; then N_PASS+=1; else N_FAIL+=1; fi
+}
+
+# --- Run sequentially (parallelism deferred) -------------------------------
+for i in "${!ALIASES[@]}"; do
+  run_one "$i"
+done
+
+# --- Render report ---------------------------------------------------------
+{
+  echo "# distro-matrix report"
+  echo
+  echo "- timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- scanner: \`$SCANNER\`"
+  echo "- distros: ${#ALIASES[@]} (pass: $N_PASS, fail: $N_FAIL)"
+  echo
+  echo "| Alias | Expected ID | Detected ID | Exit | Duration | Verdict | Notes |"
+  echo "| --- | --- | --- | --- | --- | --- | --- |"
+  for i in "${!ROW_ALIAS[@]}"; do
+    printf '| %s | %s | %s | %s | %ss | %s | %s |\n' \
+      "${ROW_ALIAS[$i]}" "${ROW_EXPECTED[$i]}" "${ROW_DETECTED[$i]:--}" \
+      "${ROW_EXIT[$i]}" "${ROW_DURATION[$i]}" "${ROW_VERDICT[$i]}" "${ROW_NOTES[$i]:--}"
+  done
+} > "$REPORT"
+
+# --- summary.json ----------------------------------------------------------
+{
+  printf '{"timestamp":"%s","scanner":"%s","total":%d,"pass":%d,"fail":%d,"results":[' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SCANNER" "${#ALIASES[@]}" "$N_PASS" "$N_FAIL"
+  for i in "${!ROW_ALIAS[@]}"; do
+    [[ $i -gt 0 ]] && printf ','
+    jq -nc --arg a "${ROW_ALIAS[$i]}" --arg e "${ROW_EXPECTED[$i]}" \
+           --arg d "${ROW_DETECTED[$i]}" --arg x "${ROW_EXIT[$i]}" \
+           --argjson dur "${ROW_DURATION[$i]}" \
+           --arg v "${ROW_VERDICT[$i]}" --arg n "${ROW_NOTES[$i]}" \
+           '{alias:$a, expected_id:$e, detected_id:$d, exit:$x, duration_s:$dur, verdict:$v, notes:$n}'
+  done
+  printf ']}\n'
+} > "$SUMMARY_JSON"
+
+log "report: $REPORT"
+log "summary: $SUMMARY_JSON"
+log "results: pass=$N_PASS fail=$N_FAIL"
+
+[[ $N_FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- ``scripts/run-matrix.sh`` boots a fresh libvirt VM per distro from a local cloud qcow2, injects a NoCloud cidata.iso so cloud-init creates a uniform ``matrix`` user with our SSH key, runs the scanner over SSH, pulls JSON output back, and emits a markdown report
- ``--parallel N`` runs N distros concurrently. Per-distro records written to ``results/<alias>/record.tsv`` so subshells don't fight over shared arrays
- NFS backing-file overlay by default: ``qemu-img create -f qcow2 -F qcow2 -b $qcow ...`` creates a thin per-VM overlay over the upstream qcow2 (read-only on NFS), avoiding GB-of-copy per VM. Falls back to full copy with ``--no-backing``
- ``--scanner-args 'STR'`` forwards extra args to the scanner (e.g. ``--json``)
- Verdict: scanner exit 0–123 = "ran cleanly" (124+ = crash from ``timeout`` or signal). Matches the matrix's purpose — we care whether the script RUNS on each OS, not what verdict it itself reports
- ``distros.tsv``: 16 entries (RHEL 8/9/10, Rocky 8/9/10, AlmaLinux 8/9/10, CentOS Stream 9/10, Fedora 44, Ubuntu 24.04/25.10, Debian 12/13). debian-12 commented out pending #3
- SLES slot reserved (needs SCC qcow2 download)

### Why libvirt + cloud-localds, not Incus

The earlier Incus path (commit ``9fad055``) required either Incus-flavored stripped images (no cloud-init, no sshd, defeats the purpose of testing upstream cloud images) or wrestling with Incus-side cloud-init injection that silently no-ops on hand-imported qcow2s. ``cloud-localds`` is what every upstream cloud image is tested against.

## Wall-clock (lennon: 4070 Ti, 32 threads, 128 GiB)

| Mode | Distros | Time |
| --- | --- | --- |
| sequential | 1 | ~18s |
| ``--parallel 4`` | 4 | ~25s |
| ``--parallel 8`` | 15 | **~1m08s** |

## Validation

Full matrix run with ``pqc_readiness.py --json``:

| Verdict | Count | Distros |
| --- | --- | --- |
| PASS | 12 | rhel-{9,10}, rocky-{9,10}, alma-{9,10}, centos-stream-{9,10}, fedora-44, ubuntu-{24.04,25.10}, debian-13 |
| FAIL | 3 | rhel-8, rocky-8, alma-8 — all hit [pqc-readiness#36](https://github.com/aclater/pqc-readiness/issues/36) (EL8 cloud images ship python3.6/3.8 without ``/usr/bin/python3`` symlink, ``env python3`` exits 127) |

## Test plan

- [x] Single-distro smoke test: rhel-9 PASS in 18s
- [x] Parallel test: 4 distros at ``--parallel 4`` in 25s, 4 PASS
- [x] Full matrix: 15 distros at ``--parallel 8`` in 68s, 12 PASS / 3 FAIL (real bug surfaced)
- [x] Wrapper integration: ``test-on-distros`` on harrison drives the runner over SSH
- [x] CodeRabbit review: 1 race fixed (``wait -n`` under ``set -e``)

Closes #1
Refs #3 (debian-12 hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)