### PR TITLE
docs: add README + LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,172 @@
+# distro-matrix
+
+Local CI for host-level scanners across upstream Linux cloud images.
+
+Spin up a fresh libvirt VM per distro (RHEL / Rocky / AlmaLinux / CentOS Stream / Fedora / Ubuntu / Debian / SLES), run an arbitrary scanner script inside as root, pull JSON output back, and report per-distro pass/fail. The same matrix runner backs the `test-on-distros` wrapper that agents call before submitting PRs that touch host-level behavior.
+
+## Why
+
+The Tier 1 / Tier 2 distro list in projects like [pqc-readiness](https://github.com/aclater/pqc-readiness) is a promise: *"this script works on these distros."* Verifying that promise means actually booting each distro and running the script, not just running pytest in CI. This repo is the harness.
+
+`virt-install` + `cloud-localds` is what every upstream cloud image is tested against — it just works. (We tried Incus first; the public `images:` distros are stripped down without `cloud-init` or `sshd`, and Incus-side cloud-init injection silently no-ops on hand-imported qcow2s. See PR #2 commit history.)
+
+## Quick start
+
+On a host with `libvirt`, `virt-install`, `cloud-localds`, `qemu-img`, `jq`, `ssh`, and the user in the `libvirt` group:
+
+```
+git clone https://github.com/aclater/distro-matrix
+cd distro-matrix
+./scripts/run-matrix.sh \
+  --scanner ./your-script.sh \
+  --scanner-args '--json' \
+  --image-root /mnt/media/iso/linux \
+  --only debian-13 \
+  --parallel 1
+```
+
+The runner stages a thin qcow2 overlay, builds a NoCloud cidata.iso with cloud-init that creates a `matrix` user (sudo NOPASSWD + your SSH pubkey), boots the VM via `virt-install --import`, waits for IPv4 + SSH, SCPs your scanner in, runs it as root, pulls `result.json` + `stderr.log` + `exit-code` + `/etc/os-release` back, and writes a markdown report to `results/<UTC ts>/report.md`.
+
+## Two ways to use it
+
+### Direct — for matrix runs you control
+
+`scripts/run-matrix.sh` is the workhorse. Configure `distros.tsv` with the distros you care about (alias, family, expected `os-release` ID, qcow2 path relative to `--image-root`), point at a scanner, run.
+
+### Via wrapper — for agent CI
+
+`~/.local/bin/test-on-distros` (lives outside this repo, in your `$PATH`) is a thin SSH wrapper that pushes a local scanner to a remote host running this repo and prints the report back. Designed for the "before I open a PR, does my change still work on rhel-9 and debian-13?" workflow:
+
+```
+test-on-distros --scanner ./pqc_readiness.py --scanner-args '--json' --only rhel-9,debian-13 --parallel 4
+```
+
+See `~/.claude/CLAUDE.md` for the agent integration story (when to invoke, when not to, how to handle failures).
+
+## How a VM is built
+
+```
+upstream qcow2 (NFS, read-only)
+        │
+        │  qemu-img create -F qcow2 -b ...   (thin overlay; fast)
+        ▼
+   work/disk.qcow2  ──┐
+                      │
+   user-data ──┐      │
+   meta-data ──┴──> cloud-localds cidata.iso
+                      │
+                      ▼
+   virt-install --import \
+     --disk path=work/disk.qcow2 \
+     --disk path=work/cidata.iso,device=cdrom \
+     --network network=default
+                      │
+                      ▼
+   libvirt boots VM ──> cloud-init reads cidata.iso (NoCloud datasource)
+                                │
+                                ▼
+                        creates `matrix` user (sudo NOPASSWD, our SSH key)
+                                │
+                                ▼
+                        runner waits for IPv4, SSHes in, runs scanner
+                                │
+                                ▼
+                        SCP result.json / stderr.log / exit-code back
+                                │
+                                ▼
+                        cleanup: virsh destroy + undefine, rm work dir
+```
+
+## Verdict semantics
+
+| Verdict | Condition |
+| --- | --- |
+| `PASS` | Scanner exit ∈ [0, 124) **and** `result.json` is non-empty **and** the guest's `/etc/os-release` `ID` matches the expected value |
+| `FAIL` | Scanner exit 124+ (timeout / SIGKILL / signal / wrapper error), OR empty `result.json`, OR os-id mismatch |
+
+The matrix's job is *"did the script run on this OS"*, not *"what verdict did the script reach."* A scanner that exits 3 because it found a host with low capability is still a `PASS` — the script worked. A scanner that crashes (exit 137 from OOM, exit 124 from `timeout`, exit 127 from missing interpreter) is a `FAIL`.
+
+## Wall-clock (lennon: AMD Ryzen 9 3950X, 32 threads, 128 GiB)
+
+| Mode | Distros | Time |
+| --- | --- | --- |
+| sequential | 1 | ~18s |
+| `--parallel 4` | 4 | ~25s |
+| `--parallel 8` | 15 | ~1m08s |
+
+NFS-mounted qcow2s, 10 GbE direct between lennon and the storage host. The thin backing-file overlay means VM startup reads the base image lazily over NFS — no per-VM copy.
+
+## Supported distros
+
+| Family | Aliases |
+| --- | --- |
+| EL | `rhel-{8,9,10}`, `rocky-{8,9,10}`, `alma-{8,9,10}`, `centos-stream-{9,10}`, `fedora-44` |
+| Debian | `debian-13` (debian-12 disabled — see [#3](https://github.com/aclater/distro-matrix/issues/3)) |
+| Ubuntu | `ubuntu-24.04`, `ubuntu-25.10` |
+| SUSE | slot reserved (needs SCC qcow2 download — see below) |
+
+`distros.tsv` is the source of truth. CentOS Stream 8 is excluded (EOL 2024-05-31).
+
+## How to add a distro
+
+1. Download the upstream cloud qcow2 to `<image-root>/<distro-dir>/`. Use the dated filename so on-disk provenance is intact.
+2. Append a row to `distros.tsv`:
+   ```
+   <alias>	<family>	<expected_os_id>	<distro-dir>/<filename>.qcow2
+   ```
+   - `family` is informational (`rhel`, `debian`, `suse`)
+   - `expected_os_id` is the `ID=` value the scanner-side `awk` will read from `/etc/os-release` inside the VM (`debian`, `ubuntu`, `rhel`, `rocky`, `almalinux`, `centos`, `fedora`, `sles`)
+3. Run `./scripts/run-matrix.sh --only <alias>` to verify.
+
+## SLES 15 SP6+
+
+Reserved slot — populate by hand (SCC registration required, can't be scripted):
+
+1. Sign in to <https://scc.suse.com> with a free Developer subscription
+2. Download the SLES 15 SP6 (or SP7) JeOS qcow2 to `<image-root>/sles/`
+3. Uncomment and adjust the `sles-15` line in `distros.tsv`
+
+## Known issues
+
+- **debian-12** boots but never acquires a DHCPv4 lease — root cause TBD. Tracked in [#3](https://github.com/aclater/distro-matrix/issues/3). Currently commented out in `distros.tsv`.
+- **EL8 family** scanners that use `#!/usr/bin/env python3` will exit 127 — RHEL/Rocky/AlmaLinux 8 cloud images ship `python3.6`/`python3.8` without the `/usr/bin/python3` symlink (operator must `dnf install python3` or `alternatives --set python3`). Not a `distro-matrix` bug, but matrix runs against scanners with this assumption will FAIL on EL8 — see [pqc-readiness#36](https://github.com/aclater/pqc-readiness/issues/36) for the canonical bug-report shape.
+
+## Output layout
+
+```
+results/
+  20260429T011526Z/
+    report.md            ← the markdown table you read first
+    summary.json         ← machine-readable per-distro records
+    rhel-9/
+      result.json        ← scanner stdout
+      stderr.log         ← scanner stderr
+      exit-code          ← scanner exit code
+      os-release         ← guest /etc/os-release (ground truth)
+      virt.log           ← virt-install + virsh + scp output
+      record.tsv         ← per-distro tab-separated record (parallelism-safe aggregation)
+```
+
+## Repository layout
+
+```
+.
+├── CLAUDE.md                  agent instructions for this repo (and the rest of aclater/*)
+├── README.md                  this file
+├── distros.tsv                source of truth for the matrix
+├── scripts/run-matrix.sh      the runner
+├── .github/workflows/         shellcheck CI, Trivy, OpenSSF Scorecard, Dependabot
+├── .pre-commit-config.yaml    detect-secrets + shellcheck + hygiene hooks
+└── .secrets.baseline
+```
+
+## Contributing
+
+- File an issue first (the agent CLAUDE.md insists on this for any work).
+- One logical change per commit. Reference the issue (`Closes #N` / `Refs #N`).
+- Run `pre-commit run --all-files` and `shellcheck scripts/*.sh` locally.
+- For changes to runner behavior, exercise it on at least one EL distro (rhel-9 is fast) and one Debian-family distro (debian-13).
+
+## License
+
+[Apache-2.0](LICENSE).


### PR DESCRIPTION
## Summary

- ``README.md``: quick start, two consumption paths (direct + ``test-on-distros`` wrapper), VM lifecycle diagram, verdict semantics, wall-clock numbers, supported-distro table, how-to-add-a-distro, SLES slot instructions, known issues (debian-12 #3 + EL8 [pqc-readiness#36](https://github.com/aclater/pqc-readiness/issues/36)), output layout, repo layout, contributing notes
- ``LICENSE``: standard Apache-2.0, fetched from <https://www.apache.org/licenses/LICENSE-2.0.txt>. Folds in the LICENSE follow-up I'd opened as #5

Closes #4
Closes #5

## Test plan

- [x] README renders cleanly on GitHub (markdown table syntax + ASCII diagram all valid)
- [x] All cross-references resolve (CLAUDE.md, distros.tsv, scripts/run-matrix.sh, issues #3 / pqc-readiness#36)
- [x] LICENSE matches Apache-2.0 verbatim (202 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)