### PR TITLE
feat(ci): FIPS algorithm-fence divergence regression test

### DIFF
--- a/.github/workflows/fips-divergence-regression.yml
+++ b/.github/workflows/fips-divergence-regression.yml
@@ -1,0 +1,83 @@
+name: FIPS algorithm-fence divergence regression
+
+# Boots a 2-VM fleet under FIPS — one RHEL 10, one rebuild distro 10 —
+# runs pqc_readiness.py --json on each, and asserts the divergence
+# documented in pqc-readiness/docs/findings/fips-algorithm-fence.md
+# still holds:
+#   - RHEL FIPS-on must report zero PQC KEMs and zero PQC signatures
+#   - rebuild FIPS-on must report a non-zero count of either
+#
+# Either failure is interesting:
+#   - RHEL exposing PQC algorithms: regression in RHEL's gating patches
+#   - rebuild not exposing them:    rebuild started carrying gating
+#                                   patches; relax the test or update
+#                                   the writeup
+#
+# This workflow does not run on every PR — libvirt + a self-hosted
+# runner are the assumption.  Triggers: weekly schedule + on-demand.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  fips-divergence:
+    name: FIPS divergence (RHEL vs rebuild)
+    runs-on: [self-hosted, libvirt]
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout distro-matrix
+        uses: actions/checkout@v6.0.2
+
+      - name: Checkout pqc-readiness alongside
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: aclater/pqc-readiness
+          path: pqc-readiness
+
+      - name: Boot 2-VM FIPS fleet
+        run: |
+          cat > fleet.tsv <<'EOF'
+          rhel-10    1
+          rocky-10   1
+          EOF
+          ./scripts/spawn-fleet/spawn-fleet.sh \
+            --manifest ./fleet.tsv \
+            --memory 18432 \
+            --vcpus 2 \
+            --fips \
+            --results-dir ./fleet-fips/
+
+      - name: Run pqc_readiness.py on every host
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r vm alias family expected ip; do
+            [[ -z $vm || $ip == FAIL ]] && continue
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                pqc-readiness/pqc_readiness.py "matrix@$ip:/tmp/"
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                "matrix@$ip" "sudo python3 /tmp/pqc_readiness.py --json" \
+                > "./fleet-fips/$vm/result.json"
+          done < ./fleet-fips/fleet.tsv
+
+      - name: Assert FIPS algorithm-fence divergence
+        run: ./scripts/check-fips-divergence.py ./fleet-fips/
+
+      - name: Upload result.json artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: fleet-results
+          path: |
+            ./fleet-fips/**/result.json
+            ./fleet-fips/fleet.tsv
+            ./fleet-fips/inventory.ini
+
+      - name: Teardown fleet
+        if: always()
+        run: ./scripts/teardown-fleet.sh --results-dir ./fleet-fips/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ Reserved slot — populate by hand (SCC registration required, can't be scripted
 2. Download the SLES 15 SP6 (or SP7) JeOS qcow2 to `<image-root>/sles/`
 3. Uncomment and adjust the `sles-15` line in `distros.tsv`
 
+## Regression tests
+
+### FIPS algorithm-fence divergence
+
+`.github/workflows/fips-divergence-regression.yml` boots a 2-VM fleet (one RHEL 10, one rebuild distro 10) under FIPS, runs `pqc_readiness.py --json` on each, and asserts the divergence documented in [pqc-readiness/docs/findings/fips-algorithm-fence.md](https://github.com/aclater/pqc-readiness/blob/main/docs/findings/fips-algorithm-fence.md) holds in both directions:
+
+- The RHEL host must report **zero PQC KEMs and zero PQC signature algorithms** while FIPS is active. If it does not, RHEL's downstream FIPS-provider gating patches have regressed.
+- The rebuild host must report **non-zero PQC KEMs or signatures** while FIPS is active. If it does not, the rebuild started carrying the gating patches; investigate before relaxing the test.
+
+The assertion script is `scripts/check-fips-divergence.py`. The classifier (which distro IDs ship the patches) is a single frozenset at the top of that script — adding to it is a claim about a build, not a marketing statement.
+
+The workflow runs weekly (Mondays 07:00 UTC) and on demand via `workflow_dispatch`. It does not run on every PR — libvirt + a self-hosted runner are the assumption. On failure, both VMs' `result.json` files are uploaded as workflow artifacts.
+
 ## Known issues
 
 - **debian-12** boots but never acquires a DHCPv4 lease — root cause TBD. Tracked in [#3](https://github.com/aclater/distro-matrix/issues/3). Currently commented out in `distros.tsv`.

--- a/scripts/check-fips-divergence.py
+++ b/scripts/check-fips-divergence.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Assert the FIPS algorithm-fence divergence still holds.
+
+Reads result.json files from a spawn-fleet results directory, classifies
+each host into "rhel-family-with-gating-patches" or "other-rebuild" by
+os_release.id, and asserts:
+
+  - hosts with the gating patches expose zero PQC KEMs and zero PQC
+    signature algorithms while FIPS is active
+  - hosts without them expose a non-zero count of either
+
+Either failure is interesting and surfaces as a non-zero exit:
+
+  rc=1: the rebuild stopped exposing PQC (rebuild started carrying the
+        gating patches; investigate, possibly relax this test)
+  rc=2: RHEL started exposing PQC (regression in RHEL's gating patches;
+        file a bug)
+  rc=3: per-host expectation file format unrecognized
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Distros that ship the downstream FIPS-provider gating patches.  Kept
+# narrow on purpose: this list is the canonical answer to "which distro
+# IDs do we expect zero-PQC under FIPS from?"  Adding to this list is a
+# claim about a build, not a marketing statement.
+HOSTS_WITH_GATING_PATCHES = frozenset({"rhel"})
+
+
+def classify(os_release_id: str) -> str:
+    if os_release_id in HOSTS_WITH_GATING_PATCHES:
+        return "with_gating"
+    return "without_gating"
+
+
+def count_pqc(report: dict) -> tuple[int, int]:
+    openssl = report.get("openssl") or {}
+    return (
+        len(openssl.get("kem_algorithms") or []),
+        len(openssl.get("sig_algorithms") or []),
+    )
+
+
+def main(results_dir: Path) -> int:
+    fleet_tsv = results_dir / "fleet.tsv"
+    if not fleet_tsv.is_file():
+        print(f"missing fleet.tsv at {fleet_tsv}", file=sys.stderr)
+        return 3
+
+    with_gating_failures: list[str] = []
+    without_gating_failures: list[str] = []
+
+    rows = [
+        line.split("\t")
+        for line in fleet_tsv.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+    for row in rows:
+        if len(row) < 5:
+            continue
+        vm = row[0]
+        result_path = results_dir / vm / "result.json"
+        if not result_path.is_file():
+            print(f"[{vm}] no result.json — skipping")
+            continue
+        report = json.loads(result_path.read_text())
+        os_id = (report.get("os_release") or {}).get("id", "unknown")
+        klass = classify(os_id)
+        kem_count, sig_count = count_pqc(report)
+
+        fips_active = (report.get("fips") or {}).get("openssl_provider")
+        if not fips_active:
+            print(f"[{vm}] FIPS not active — skipping")
+            continue
+
+        print(
+            f"[{vm}] os_id={os_id} class={klass} "
+            f"kems={kem_count} sigs={sig_count}"
+        )
+
+        if klass == "with_gating" and (kem_count or sig_count):
+            with_gating_failures.append(
+                f"{vm} ({os_id}): exposed {kem_count} KEMs / "
+                f"{sig_count} sigs under FIPS"
+            )
+        if klass == "without_gating" and not (kem_count or sig_count):
+            without_gating_failures.append(
+                f"{vm} ({os_id}): zero PQC KEMs and sigs under FIPS — "
+                "did the rebuild start carrying the gating patches?"
+            )
+
+    if with_gating_failures:
+        print("\nFAIL: gating-patch host(s) exposed PQC under FIPS:")
+        for f in with_gating_failures:
+            print(f"  - {f}")
+        return 2
+    if without_gating_failures:
+        print("\nFAIL: non-gating-patch host(s) did NOT expose PQC under FIPS:")
+        for f in without_gating_failures:
+            print(f"  - {f}")
+        return 1
+    print("\nOK: divergence holds in both directions")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <results-dir>", file=sys.stderr)
+        sys.exit(64)
+    sys.exit(main(Path(sys.argv[1])))


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/fips-divergence-regression.yml` boots a 2-VM fleet under FIPS via `spawn-fleet.sh --fips`, runs `pqc_readiness.py --json` on each, asserts the divergence holds.
- New asserter `scripts/check-fips-divergence.py` reads each host's `result.json`, classifies by `os_release.id`, fails build on either-direction divergence break.
- Smoke-tested the asserter locally with synthetic JSON (RHEL zero-PQC + Rocky 1-KEM-1-sig → rc=0; flipped expectations → rc=1 / rc=2).
- README adds a "Regression tests" section documenting expected behavior, classifier extension policy, and trigger schedule.

## Test plan

- [x] Asserter logic exercised against synthetic fixtures (both pass and fail directions)
- [ ] **Cannot validate end-to-end from this host** — needs libvirt + the self-hosted runner; will only run for real on Mondays or via `workflow_dispatch`
- [x] Action versions verified via API (`actions/upload-artifact@v7.0.1`, `actions/checkout@v6.0.2`)

## Dependencies

Depends on #9 (spawn-fleet.sh) — the workflow imports the script. Merge #9 first.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)